### PR TITLE
fix(serde_at): deserialize _

### DIFF
--- a/atat/src/blocking/client.rs
+++ b/atat/src/blocking/client.rs
@@ -424,30 +424,6 @@ mod test {
     }
 
     #[tokio::test]
-    async fn invalid_response() {
-        let (mut client, mut tx, rx) = setup!(Config::new());
-
-        // String last
-        let cmd = TestRespStringCmd {
-            fun: Functionality::APM,
-            rst: Some(ResetMode::DontReset),
-        };
-
-        let sent = tokio::spawn(async move {
-            tx.next_message_pure().await;
-            rx.signal_response(Ok(b"+CUN: 22,16,22")).unwrap();
-        });
-
-        tokio::task::spawn_blocking(move || {
-            assert_eq!(Err(Error::Parse), client.send(&cmd));
-        })
-        .await
-        .unwrap();
-
-        sent.await.unwrap();
-    }
-
-    #[tokio::test]
     async fn custom_timeout() {
         static CALL_COUNT: AtomicU64 = AtomicU64::new(0);
 

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -178,7 +178,7 @@ impl<'a> Deserializer<'a> {
                 self.index = self.slice.len();
                 return Ok(&self.slice[start..]);
             } else if let Some(c) = self.peek() {
-                if (c as char).is_ascii() && c >= 32  {
+                if (c as char).is_ascii() && c >= 32 {
                     self.eat_char();
                 } else {
                     return Err(Error::EofWhileParsingString);

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -178,7 +178,7 @@ impl<'a> Deserializer<'a> {
                 self.index = self.slice.len();
                 return Ok(&self.slice[start..]);
             } else if let Some(c) = self.peek() {
-                if (c as char).is_alphanumeric() || (c as char).is_whitespace() {
+                if (c as char).is_ascii() && c >= 32  {
                     self.eat_char();
                 } else {
                     return Err(Error::EofWhileParsingString);
@@ -473,7 +473,7 @@ impl<'a, 'de> de::Deserializer<'de> for &'a mut Deserializer<'de> {
                 visitor.visit_borrowed_str(self.parse_str()?)
             }
             _ => {
-                if (peek as char).is_alphabetic() {
+                if (peek as char).is_ascii() && peek >= 32 {
                     visitor.visit_bytes(self.parse_bytes()?)
                 } else {
                     Err(Error::InvalidType)


### PR DESCRIPTION
While parsing the CGMI of my device (SIM7020), I've noticed that I was getting a lot of parsing errors.  
After digging deeper, I've discovered that the parsing errors were actually `EofWhileParsingString` errors.  
  
Finally, I've discovered why: my manufacturer string looked like this:

```
SIMCOM_Ltd
```

And this was breaking at the `_`, because it's not considered alphanumeric.
My fix here is to allow all ASCII characters >= 32 (space + printable characters).

The only non-printable character included is `DEL` (127) - but it shouldn't be a big deal.


---

```rust
match client.send(&common::GetManufacturerId{}).await {
    Ok(resp) => {
        info!("Manufacturer ID OK: resp={:?}", resp.id.as_str());
    }
    Err(e) => {
        println!("Error: {:?}", e);
    }
}
```

Before my fix:

```
DEBUG Response: "SIMCOM_Ltd"
Error from serde_at: EofWhileParsingString
```

After my fix:
```
DEBUG Response: "SIMCOM_Ltd"
INFO Manufacturer ID OK: resp="SIMCOM_Ltd"
```