### PR TITLE
add custom separator support to LengthDelimited

### DIFF
--- a/serde_at/src/de/length_delimited.rs
+++ b/serde_at/src/de/length_delimited.rs
@@ -19,7 +19,7 @@ use serde::{de, Deserialize, Deserializer};
 /// `'4,"ABCD"' => LengthDelimited { len: 4, bytes: [65, 66, 67, 68] }`
 ///
 #[derive(Clone, Debug)]
-pub struct LengthDelimited<const N: usize> {
+pub struct LengthDelimited<const N: usize, const S: usize = 1> {
     /// The number of bytes in the payload. This is actually
     /// redundant since the `bytes` field also knows its own length.
     pub len: usize,
@@ -27,7 +27,7 @@ pub struct LengthDelimited<const N: usize> {
     pub bytes: Bytes<N>,
 }
 
-impl<'de, const N: usize> Deserialize<'de> for LengthDelimited<N> {
+impl<'de, const N: usize, const S: usize> Deserialize<'de> for LengthDelimited<N, S> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -35,13 +35,14 @@ impl<'de, const N: usize> Deserialize<'de> for LengthDelimited<N> {
         // Ideally we use deserializer.deserialize_bytes but since it clips the payload
         // at the first comma we cannot use it.
         // Instead we use deserialize_tuple as it wasn't used yet.
-        deserializer.deserialize_tuple(2, LengthDelimitedVisitor::<N>) // The '2' is dummy.
+        deserializer.deserialize_tuple(2, LengthDelimitedVisitor::<N, S>) // The '2' is dummy.
     }
 }
-struct LengthDelimitedVisitor<const N: usize>;
 
-impl<'de, const N: usize> de::Visitor<'de> for LengthDelimitedVisitor<N> {
-    type Value = LengthDelimited<N>;
+struct LengthDelimitedVisitor<const N: usize, const L: usize>;
+
+impl<'de, const N: usize, const S: usize> de::Visitor<'de> for LengthDelimitedVisitor<N, S> {
+    type Value = LengthDelimited<N, S>;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter.write_str("length delimited bytes, e.g.: \"4,ABCD\"")
@@ -52,13 +53,13 @@ impl<'de, const N: usize> de::Visitor<'de> for LengthDelimitedVisitor<N> {
         E: serde::de::Error,
     {
         v.iter()
-            .position(|&c| c == b',')
+            .position(|&c| !c.is_ascii_digit())
             .ok_or_else(|| de::Error::custom("expected a comma"))
             .and_then(|pos| {
                 let len = parse_len(&v[0..pos])
                     .map_err(|_| de::Error::custom("expected an unsigned int"))?;
-                // +1 to skip the comma after the length.
-                let mut start = pos + 1;
+                // +S to skip the separator after the length.
+                let mut start = pos + S;
                 let mut end = start + len;
                 // Check if payload is surrounded by double quotes not included in len.
                 let slice_len = v.len();

--- a/serde_at/src/de/mod.rs
+++ b/serde_at/src/de/mod.rs
@@ -969,6 +969,25 @@ mod tests {
     }
 
     #[test]
+    fn length_delimited_line_break() {
+        #[derive(Clone, Debug, Deserialize)]
+        pub struct PayloadResponse {
+            pub ctx: u8, // Some other params
+            pub id: i8,  // Some other params
+            pub payload: LengthDelimited<32, 2>,
+        }
+
+        let res: PayloadResponse = crate::from_slice(b"1,-1,9\r\nABCD,1234").unwrap();
+        assert_eq!(res.ctx, 1);
+        assert_eq!(res.id, -1);
+        assert_eq!(res.payload.len, 9);
+        assert_eq!(
+            res.payload.bytes,
+            Bytes::<32>::from_slice(b"ABCD,1234").unwrap()
+        );
+    }
+
+    #[test]
     fn length_delimited_json() {
         #[derive(Clone, Debug, Deserialize)]
         pub struct PayloadResponse {


### PR DESCRIPTION
Small improvement to the feature added here: https://github.com/FactbirdHQ/atat/pull/186

My use case is a URC of the Quectel BG95:
In "direct push mode" the modem forwards incoming socket data via URC with this format:
`+QIURC: "recv",<connectID>,<currectrecvlength><CR><LF><data>`

The `LengthDelimited` currently does not support a line break between the length and data - or any other separator than an comma.

This PR changes two things:
- instead of looking for a comma after the length, look for anything that is not a digit
- add a custom length parameter to skip over arbitrary separators

The length parameter defaults to 1, so this should not be a breaking change.

Draft PR for now, because I could not test this on an actual device yet.