### PR TITLE
Support the AT+HTTPCPOST flow for ESP32

### DIFF
--- a/atat/Cargo.toml
+++ b/atat/Cargo.toml
@@ -21,7 +21,7 @@ name = "atat"
 embedded-io = "0.6"
 embedded-io-async = "0.6"
 futures = { version = "0.3", default-features = false }
-embassy-sync = "0.6"
+embassy-sync = "0.7"
 embassy-time = "0.4"
 embassy-futures = "0.1"
 heapless = { version = "^0.8", features = ["serde"] }

--- a/atat/src/asynch/client.rs
+++ b/atat/src/asynch/client.rs
@@ -1,3 +1,5 @@
+use core::ops::{Deref, DerefMut};
+
 use super::AtatClient;
 use crate::{
     helpers::LossyStr,
@@ -17,6 +19,20 @@ pub struct Client<'a, W: Write, const INGRESS_BUF_SIZE: usize> {
     buf: &'a mut [u8],
     config: Config,
     cooldown_timer: Option<Timer>,
+}
+
+impl<'a, W: Write, const INGRESS_BUF_SIZE: usize> Deref for Client<'a, W, INGRESS_BUF_SIZE> {
+    type Target = W;
+
+    fn deref(&self) -> &Self::Target {
+        &self.writer
+    }
+}
+
+impl<'a, W: Write, const INGRESS_BUF_SIZE: usize> DerefMut for Client<'a, W, INGRESS_BUF_SIZE> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.writer
+    }
 }
 
 impl<'a, W: Write, const INGRESS_BUF_SIZE: usize> Client<'a, W, INGRESS_BUF_SIZE> {


### PR DESCRIPTION
* Updates `embassy-sync` dependency
* Implements `Deref` and `DerefMut` for `Client`
* Supports disabling the default prompt detection

To disable default prompt detection the user just calls `with_custom_prompt()` and returns `ParseError::NoMatch`:

```
let digester = DefaultDigester::<Urc>::new()
  .with_custom_prompt(|_| Err(ParseError::NoMatch));
```

Now when a custom prompt is set the default prompt is not handled. I suppose you could consider this a breaking change but the fact that previously the custom prompt logic ***and*** the default prompt logic could both execute seems like a bug to me.

If you don't want the `embassy-sync` upgrade (which i needed to be able to compile the firmware) but want the other changes let me know and I'll downgrade `embassy-sync` in this PR 👍 

Closes #232.