### PR TITLE
Skip send of commands with empty payload

### DIFF
--- a/atat/src/asynch/client.rs
+++ b/atat/src/asynch/client.rs
@@ -37,7 +37,8 @@ impl<'a, W: Write, const INGRESS_BUF_SIZE: usize> Client<'a, W, INGRESS_BUF_SIZE
     }
 
     /// Returns a mutable reference to the inner writer.
-    pub fn inner(&mut self) -> &mut W {
+    pub async fn inner(&mut self) -> &mut W {
+        self.wait_cooldown_timer().await;
         &mut self.writer
     }
 }

--- a/atat/src/asynch/client.rs
+++ b/atat/src/asynch/client.rs
@@ -38,6 +38,7 @@ impl<'a, W: Write, const INGRESS_BUF_SIZE: usize> Client<'a, W, INGRESS_BUF_SIZE
 
     /// Returns a mutable reference to the inner writer.
     pub async fn inner(&mut self) -> &mut W {
+        self.res_slot.reset();
         self.wait_cooldown_timer().await;
         &mut self.writer
     }

--- a/atat/src/asynch/client.rs
+++ b/atat/src/asynch/client.rs
@@ -48,25 +48,27 @@ impl<W: Write, const INGRESS_BUF_SIZE: usize> ErrorType for Client<'_, W, INGRES
 
 impl<'a, W: Write, const INGRESS_BUF_SIZE: usize> Client<'a, W, INGRESS_BUF_SIZE> {
     async fn send_request(&mut self, len: usize) -> Result<(), Error> {
-        if len < 50 {
-            debug!("Sending command: {:?}", LossyStr(&self.buf[..len]));
-        } else {
-            debug!("Sending command with long payload ({} bytes)", len);
+        if len > 0 {
+            if len < 50 {
+                debug!("Sending command: {:?}", LossyStr(&self.buf[..len]));
+            } else {
+                debug!("Sending command with long payload ({} bytes)", len);
+            }
+
+            self.wait_cooldown_timer().await;
+
+            // Clear any pending response signal
+            self.res_slot.reset();
+
+            // Write request
+            with_timeout(
+                self.config.tx_timeout,
+                self.writer.write_all(&self.buf[..len]),
+            )
+            .await
+            .map_err(|_| Error::Timeout)?
+            .map_err(|_| Error::Write)?;
         }
-
-        self.wait_cooldown_timer().await;
-
-        // Clear any pending response signal
-        self.res_slot.reset();
-
-        // Write request
-        with_timeout(
-            self.config.tx_timeout,
-            self.writer.write_all(&self.buf[..len]),
-        )
-        .await
-        .map_err(|_| Error::Timeout)?
-        .map_err(|_| Error::Write)?;
 
         with_timeout(self.config.flush_timeout, self.writer.flush())
             .await

--- a/atat/src/asynch/simple_client.rs
+++ b/atat/src/asynch/simple_client.rs
@@ -30,19 +30,20 @@ impl<'a, RW: Read + Write, D: Digester> SimpleClient<'a, RW, D> {
     }
 
     async fn send_request(&mut self, len: usize) -> Result<(), Error> {
-        if len < 50 {
-            debug!("Sending command: {:?}", LossyStr(&self.buf[..len]));
-        } else {
-            debug!("Sending command with long payload ({} bytes)", len);
+        if len > 0 {
+            if len < 50 {
+                debug!("Sending command: {:?}", LossyStr(&self.buf[..len]));
+            } else {
+                debug!("Sending command with long payload ({} bytes)", len);
+            }
+            self.wait_cooldown_timer().await;
+
+            // Write request
+            with_timeout(self.config.tx_timeout, self.rw.write_all(&self.buf[..len]))
+                .await
+                .map_err(|_| Error::Timeout)?
+                .map_err(|_| Error::Write)?;
         }
-
-        self.wait_cooldown_timer().await;
-
-        // Write request
-        with_timeout(self.config.tx_timeout, self.rw.write_all(&self.buf[..len]))
-            .await
-            .map_err(|_| Error::Timeout)?
-            .map_err(|_| Error::Write)?;
 
         with_timeout(self.config.flush_timeout, self.rw.flush())
             .await

--- a/atat/src/asynch/simple_client.rs
+++ b/atat/src/asynch/simple_client.rs
@@ -25,7 +25,8 @@ impl<'a, RW: Read + Write, D: Digester> SimpleClient<'a, RW, D> {
     }
 
     /// Returns a mutable reference to the inner reader/writer.
-    pub fn inner(&mut self) -> &mut RW {
+    pub async fn inner(&mut self) -> &mut RW {
+        self.wait_cooldown_timer().await;
         &mut self.rw
     }
 

--- a/atat/src/blocking/client.rs
+++ b/atat/src/blocking/client.rs
@@ -45,6 +45,7 @@ where
 
     /// Returns a mutable reference to the inner writer.
     pub fn inner(&mut self) -> &mut W {
+        self.res_slot.reset();
         self.wait_cooldown_timer();
         &mut self.writer
     }

--- a/atat/src/blocking/client.rs
+++ b/atat/src/blocking/client.rs
@@ -45,6 +45,7 @@ where
 
     /// Returns a mutable reference to the inner writer.
     pub fn inner(&mut self) -> &mut W {
+        self.wait_cooldown_timer();
         &mut self.writer
     }
 

--- a/atat/src/blocking/client.rs
+++ b/atat/src/blocking/client.rs
@@ -49,21 +49,23 @@ where
     }
 
     fn send_request(&mut self, len: usize) -> Result<(), Error> {
-        if len < 50 {
-            debug!("Sending command: {:?}", LossyStr(&self.buf[..len]));
-        } else {
-            debug!("Sending command with long payload ({} bytes)", len,);
+        if len > 0 {
+            if len < 50 {
+                debug!("Sending command: {:?}", LossyStr(&self.buf[..len]));
+            } else {
+                debug!("Sending command with long payload ({} bytes)", len);
+            }
+            self.wait_cooldown_timer();
+
+            // Clear any pending response signal
+            self.res_slot.reset();
+
+            // Write request
+            self.writer
+                .write_all(&self.buf[..len])
+                .map_err(|_| Error::Write)?;
         }
 
-        self.wait_cooldown_timer();
-
-        // Clear any pending response signal
-        self.res_slot.reset();
-
-        // Write request
-        self.writer
-            .write_all(&self.buf[..len])
-            .map_err(|_| Error::Write)?;
         self.writer.flush().map_err(|_| Error::Write)?;
 
         self.start_cooldown_timer();

--- a/atat/src/blocking/simple_client.rs
+++ b/atat/src/blocking/simple_client.rs
@@ -30,20 +30,22 @@ impl<'a, RW: Read + Write + ReadReady + WriteReady, D: Digester> SimpleClient<'a
     }
 
     fn send_request(&mut self, len: usize) -> Result<(), Error> {
-        if len < 50 {
-            debug!("Sending command: {:?}", LossyStr(&self.buf[..len]));
-        } else {
-            debug!("Sending command with long payload ({} bytes)", len);
-        }
+        if len > 0 {
+            if len < 50 {
+                debug!("Sending command: {:?}", LossyStr(&self.buf[..len]));
+            } else {
+                debug!("Sending command with long payload ({} bytes)", len);
+            }
 
-        self.wait_cooldown_timer();
+            self.wait_cooldown_timer();
 
-        // Write request
-        let until = Instant::now() + self.config.tx_timeout;
-        let mut pos = 0;
-        while pos < len {
-            wait_for_write(&mut self.rw, until)?;
-            pos += self.rw.write(&self.buf[pos..len]).or(Err(Error::Write))?;
+            // Write request
+            let until = Instant::now() + self.config.tx_timeout;
+            let mut pos = 0;
+            while pos < len {
+                wait_for_write(&mut self.rw, until)?;
+                pos += self.rw.write(&self.buf[pos..len]).or(Err(Error::Write))?;
+            }
         }
 
         let until = Instant::now() + self.config.flush_timeout;

--- a/atat/src/blocking/simple_client.rs
+++ b/atat/src/blocking/simple_client.rs
@@ -26,6 +26,7 @@ impl<'a, RW: Read + Write + ReadReady + WriteReady, D: Digester> SimpleClient<'a
 
     /// Returns a mutable reference to the inner reader/writer.
     pub fn inner(&mut self) -> &mut RW {
+        self.wait_cooldown_timer();
         &mut self.rw
     }
 


### PR DESCRIPTION
I'll give a bit of context to understand how I'm using this change.

I need to be able to stream kilobytes (if not megabytes) of data through the AT command stream, and the current `AtatCmd` trait is a limitation.

The workaround I've found, for which this PR is needed is to use something like this:
```rust
async fn send_lots_of_data(client: &MyClient, mut source: impl embedded_io_async::Read) -> Result<...> {
    let mut buffer = [0u8; 1024];
    let w = client.atat_client.inner();
    while let Ok(len & 1..) = source.read(&mut buffer).await?; {
        w.write_all(&buffer[..len]).await?;
    }
    client.manual_response().await
}

struct Manual;

impl atat::AtatCmd for Manual {
    type Response = NoResponse;

    fn write(&self, _buf: &mut [u8]) -> usize {
        0
    }

    fn parse(&self, resp: Result<&[u8], atat::InternalError>) -> Result<Data<N>, atat::Error> {
        Ok(NoResponse)
    }
}

impl MyClient {
    async fn manual_response(&mut self) -> Result<(), atat::Error> {
        self.atat_client.send(&Manual).await?;
        Ok(())
    }
}
```

So the writing part is done manually, while the response receive is done via the `AtatClient` logic.

Moving the cooldown logic to the `inner()` method allows using the same logic also for the manual send.

@Kezii 